### PR TITLE
Avoid move assignment for streams

### DIFF
--- a/zmolly.cpp
+++ b/zmolly.cpp
@@ -856,14 +856,14 @@ int main(int argc, char** argv) {
     }
 
     // open input file
-    auto fin = std::ifstream(std::string() + argv[2], std::ios::in | std::ios::binary);
+    std::ifstream fin(argv[2], std::ios::in | std::ios::binary);
     fin.exceptions(std::ios_base::failbit);
     if (!fin.is_open()) {
         throw std::runtime_error(std::string() + "cannot open input file: " + argv[2]);
     }
 
     // open output file
-    auto fout = std::ofstream(argv[3], std::ios::out | std::ios::binary);
+    std::ofstream fout(argv[3], std::ios::out | std::ios::binary);
     fin.exceptions(std::ios_base::failbit);
     if (!fout.is_open()) {
         throw std::runtime_error(std::string() + "cannot open output file: " + argv[3]);


### PR DESCRIPTION
libstdc++ bundled with GCC older than 5 doesn't have movable streams.
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=53626

Using move assignment for stream can be easily avoided here.
Also improve consistency and readability by not creating string for
stream's filename explicitly.